### PR TITLE
Fix bug with inset positioning

### DIFF
--- a/cartogram_generator/rescale_map.cpp
+++ b/cartogram_generator/rescale_map.cpp
@@ -152,9 +152,9 @@ void shift_insets_to_target_position(CartogramInfo *cart_info)
   for (auto &inset_state : *cart_info->ref_to_inset_states()) {
     bboxes.at(inset_state.pos()) = inset_state.bbox();
   }
-  double x = 0;
-  double y = 0;
   for (auto &inset_state : *cart_info->ref_to_inset_states()) {
+    double x = 0;
+    double y = 0;
     const std::string pos = inset_state.pos();
     if (pos == "R") {
       x = std::max(bboxes.at("C").xmax(), bboxes.at("B").xmax());


### PR DESCRIPTION
We were initializing x, y before the for-loop. So, when C inset wasn't no.1 row, it was using the x,y values of whichever inset that was in no.1 row position.