### PR TITLE
Output valid geojson

### DIFF
--- a/src/cartogram_info/write_geojson.cpp
+++ b/src/cartogram_info/write_geojson.cpp
@@ -180,10 +180,14 @@ void CartogramInfo::write_geojson(
       }
     }
   }
-  new_json.push_back({"type", old_json["type"]});
-  new_json.push_back({"bbox", container[(container.size() - 2)]});
+  if (n_insets() == 1) {
+    new_json.push_back({"bbox", container[(container.size() - 1)]});
+  } else {
+    new_json.push_back({"bbox", container[(container.size() - 2)]});
+    new_json.push_back({"divider_points", container[(container.size() - 1)]});
+  }
   new_json.push_back({"crs", "custom"});
-  new_json.push_back({"divider_points", container[(container.size() - 1)]});
+  new_json.push_back({"type", old_json["type"]});
   if (output_to_stdout) {
     new_geo_stream << new_json << std::endl;
   } else {


### PR DESCRIPTION
Minor changes that should yield valid cartogram GeoJSON files. The validity of the GeoJSON files can be checked at this link: https://www.itb.ec.europa.eu/json/geojson/upload.

The `ordered_json` type was also used to make sure the GeoJSON key value pairs are written in the correct order. QGIS is sensitive to this.