### PR TITLE
Fix to ```Segmentation fault``` issue when plotting polygons and results numbering when stress testing, update to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ conan install . --output-folder build --build=missing -s build_type=Release -s c
 ```
 
 ```
-sudo make install -j4 -C build
+.venv/bin/cmake --build build -j4
+```
+
+```
+sudo .venv/bin/cmake --install build
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ conan install . --output-folder build --build=missing -s build_type=Release -s c
 ```
 
 ```
-.venv/bin/cmake --build build -j4  
+sudo make install -j4 -C build
 ```
 
 

--- a/include/progress_tracker.hpp
+++ b/include/progress_tracker.hpp
@@ -1,6 +1,7 @@
 #ifndef PROGRESS_TRACKER_H
 #define PROGRESS_TRACKER_H
 
+#include <cstdint>
 #include "indicators/block_progress_bar.hpp"
 #include "indicators/color.hpp"
 #include "indicators/cursor_control.hpp"

--- a/src/inset_state/fill_with_density_clip.cpp
+++ b/src/inset_state/fill_with_density_clip.cpp
@@ -1096,10 +1096,10 @@ void InsetState::create_contiguity_graph()
   is_copy.rescale_map();
 
   boost::multi_array<std::vector<PolygonInfo>, 2> edge_cell_polyinfo(
-    boost::extents[lx_][ly_]);
+    boost::extents[is_copy.lx_][is_copy.ly_]);
   std::vector<PolygonInfo> all_pwh_info;
 
-  process_geo_divisions_edge_info(edge_cell_polyinfo, all_pwh_info, *this);
+  process_geo_divisions_edge_info(edge_cell_polyinfo, all_pwh_info, is_copy);
 
   for (unsigned int x = 0; x < is_copy.lx(); ++x) {
     for (unsigned int y = 0; y < is_copy.ly(); ++y) {

--- a/tests/stress_test.sh
+++ b/tests/stress_test.sh
@@ -373,7 +373,7 @@ if [ $flags -eq 1 ]; then
 
     printf "${flags_arr[$i]}:\n" | tee -a "${results_file}"
     failed_per=$((100 * $failed / $total))
-    printf "Passed [$((total - total_failed))/${total}] | $((100 - failed_per))%% \n" | tee -a "${results_file}" | color $green
+    printf "Passed [$((total - failed))/${total}] | $((100 - failed_per))%% \n" | tee -a "${results_file}" | color $green
     printf "Failed [${failed}/${total}] | ${failed_per}%% \n" | tee -a "${results_file}" | color $red
   done
   printf "Combined tests:\n" | tee -a "${results_file}"


### PR DESCRIPTION
@nihalzp @adisidev 
This pull request features a few changes made to the project code. The changes are as follows:
- Fix to the `Segmentation fault` issue that is sometimes faced when using the `--plot_polygons` flag (issue occurs if the regions do not have colors and `auto_color()` is used)
- Minor fix to the results numbering when performing extensive stress tests with all flags
- Update to the README so that the project build commands installs the cartogram program as well