### PR TITLE
Fix to `_Exit()` issue and error handling for `map.at(key)` issue

### DIFF
--- a/src/cartogram_info/read_csv.cpp
+++ b/src/cartogram_info/read_csv.cpp
@@ -336,14 +336,18 @@ void CartogramInfo::read_csv()
     const std::string area_as_str = row[static_cast<size_t>(area_col)].get();
     check_validity_of_area_str(area_as_str);
 
-    const std::string color =
-      (color_col != csv::CSV_NOT_FOUND) ? row[static_cast<size_t>(color_col)].get() : "";
+    const std::string color = (color_col != csv::CSV_NOT_FOUND)
+                                ? row[static_cast<size_t>(color_col)].get()
+                                : "";
 
-    const std::string label =
-      (label_col != csv::CSV_NOT_FOUND) ? row[static_cast<size_t>(label_col)].get() : "";
+    const std::string label = (label_col != csv::CSV_NOT_FOUND)
+                                ? row[static_cast<size_t>(label_col)].get()
+                                : "";
 
     const std::string inset_pos_as_str =
-      (inset_col != csv::CSV_NOT_FOUND) ? row[static_cast<size_t>(inset_col)].get() : "C";
+      (inset_col != csv::CSV_NOT_FOUND)
+        ? row[static_cast<size_t>(inset_col)].get()
+        : "C";
 
     const std::string inset_pos = process_inset_pos_str(inset_pos_as_str);
     check_validity_of_inset_pos(inset_pos, id);

--- a/src/cartogram_info/read_csv.cpp
+++ b/src/cartogram_info/read_csv.cpp
@@ -33,7 +33,7 @@ static void check_validity_of_area_str(const std::string &area_as_str)
       << "ERROR: Invalid area string: " << area_process_str
       << ". Area string must only contain 0-9, '.', '-' and ',' or 'NA'."
       << std::endl;
-    _Exit(18);
+    std::exit(18);
   }
 
   if (
@@ -41,12 +41,12 @@ static void check_validity_of_area_str(const std::string &area_as_str)
     !StringToDecimalConverter::is_str_correct_format(area_process_str)) {
     std::cerr << "ERROR: Invalid area string format: " << area_process_str
               << std::endl;
-    _Exit(19);
+    std::exit(19);
   }
 
   if (area_process_str.front() == '-') {
     std::cerr << "ERROR: Negative area in CSV" << std::endl;
-    _Exit(101);
+    std::exit(101);
   }
 }
 
@@ -78,7 +78,7 @@ static void check_validity_of_inset_pos(
     std::cerr << "Unrecognized inset position : " << inset_pos
               << " for Region: " << id << "\nSetting " << id
               << "\'s inset position to Center (C)." << std::endl;
-    _Exit(20);
+    std::exit(20);
   }
 }
 
@@ -162,7 +162,7 @@ std::string CartogramInfo::match_id_columns(
     std::cerr << "ERROR: No valid matching ID header between GeoJSON "
                  "properties and CSV columns could be found."
               << std::endl;
-    _Exit(16);
+    std::exit(16);
   }
 
   id_col_ = reader.index_of(csv_id_header);
@@ -215,7 +215,7 @@ static void check_validity_of_csv_ids(
       initial_id_order.end()) {
       std::cerr << "ERROR: ID " << id << " in CSV is not in GeoJSON"
                 << std::endl;
-      _Exit(21);
+      std::exit(21);
     }
   }
 
@@ -225,7 +225,7 @@ static void check_validity_of_csv_ids(
                 << std::endl;
       csv_data[id] =
         {{"area", "NA"}, {"color", ""}, {"label", ""}, {"inset_pos", "C"}};
-      // _Exit(22);
+      // std::exit(22);
     }
   }
 }
@@ -329,7 +329,7 @@ void CartogramInfo::read_csv()
         << "ERROR: CSV with >= 2 columns (IDs, target areas) required. Some "
            "rows in your CSV may not have values for all columns"
         << std::endl;
-      _Exit(17);
+      std::exit(17);
     }
 
     const std::string id = row[static_cast<size_t>(id_col)].get();

--- a/src/cartogram_info/read_geojson.cpp
+++ b/src/cartogram_info/read_geojson.cpp
@@ -14,49 +14,49 @@ static void check_geojson_validity(const nlohmann::json &j)
 {
   if (!j.contains(std::string{"type"})) {
     std::cerr << "ERROR: JSON does not contain a key 'type'" << std::endl;
-    _Exit(4);
+    std::exit(4);
   }
   if (j["type"] != "FeatureCollection") {
     std::cerr << "ERROR: JSON is not a valid GeoJSON FeatureCollection"
               << std::endl;
-    _Exit(5);
+    std::exit(5);
   }
   if (!j.contains(std::string{"features"})) {
     std::cerr << "ERROR: JSON does not contain a key 'features'" << std::endl;
-    _Exit(6);
+    std::exit(6);
   }
   const auto &features = j["features"];
   for (const auto &feature : features) {
     if (!feature.contains(std::string{"type"})) {
       std::cerr << "ERROR: JSON contains a 'Features' element without key "
                 << "'type'" << std::endl;
-      _Exit(7);
+      std::exit(7);
     }
     if (feature["type"] != "Feature") {
       std::cerr << "ERROR: JSON contains a 'Features' element whose type "
                 << "is not 'Feature'" << std::endl;
-      _Exit(8);
+      std::exit(8);
     }
     if (!feature.contains(std::string("geometry"))) {
       std::cerr << "ERROR: JSON contains a feature without key 'geometry'"
                 << std::endl;
-      _Exit(9);
+      std::exit(9);
     }
     const auto &geometry = feature["geometry"];
     if (!geometry.contains(std::string("type"))) {
       std::cerr << "ERROR: JSON contains geometry without key 'type'"
                 << std::endl;
-      _Exit(10);
+      std::exit(10);
     }
     if (!geometry.contains(std::string("coordinates"))) {
       std::cerr << "ERROR: JSON contains geometry without key 'coordinates'"
                 << std::endl;
-      _Exit(11);
+      std::exit(11);
     }
     if (geometry["type"] != "MultiPolygon" && geometry["type"] != "Polygon") {
       std::cerr << "ERROR: JSON contains unsupported geometry "
                 << geometry["type"] << std::endl;
-      _Exit(12);
+      std::exit(12);
     }
   }
 }
@@ -97,7 +97,7 @@ static std::pair<GeoDiv, bool> json_to_geodiv(
     }
     if (!ext_ring.is_simple()) {
       std::cerr << "ERROR: (GeoJSON Parsing) exterior ring not a simple polygon" << std::endl;
-      _Exit(13);
+      std::exit(13);
     }
 
     // We adopt the convention that exterior rings are counterclockwise
@@ -134,7 +134,7 @@ static std::pair<GeoDiv, bool> json_to_geodiv(
       }
       if (!int_ring.is_simple()) {
         std::cerr << "ERROR: (GeoJSON Parsing) interior ring not a simple polygon" << std::endl;
-        _Exit(14);
+        std::exit(14);
       }
       if (int_ring.is_counterclockwise_oriented()) {
         int_ring.reverse_orientation();
@@ -182,7 +182,7 @@ static nlohmann::json load_geojson(const std::string &geometry_file_name)
   if (!in_file) {
     std::cerr << "ERROR reading GeoJSON: failed to open " << geometry_file_name
               << std::endl;
-    _Exit(3);
+    std::exit(3);
   }
 
   nlohmann::json j;
@@ -191,7 +191,7 @@ static nlohmann::json load_geojson(const std::string &geometry_file_name)
   } catch (nlohmann::json::parse_error &e) {
     std::cerr << "ERROR: " << e.what() << ". Exception id: " << e.id
               << ". Byte position of error: " << e.byte << std::endl;
-    _Exit(3);
+    std::exit(3);
   }
 
   return j;
@@ -235,7 +235,7 @@ static std::map<std::string, std::vector<std::string>> extract_unique_properties
 
   if (unique_properties_map.empty()) {
     std::cerr << "ERROR: No unique properties found in GeoJSON" << std::endl;
-    _Exit(15);
+    std::exit(15);
   }
 
   return unique_properties_map;
@@ -393,7 +393,7 @@ void CartogramInfo::read_geojson()
     // Update map_name to be based on geometry file name instead
     set_map_name(geometry_file_name);
     generate_csv_template(j, map_name_);
-    _Exit(19);
+    std::exit(19);
   }
 
   extract_crs(j, crs_);

--- a/src/draw/common/basic_figures.hpp
+++ b/src/draw/common/basic_figures.hpp
@@ -18,8 +18,7 @@ inline void write_triangles(
 
   for (Delaunay::Finite_faces_iterator fit = proj.dt.finite_faces_begin();
        fit != proj.dt.finite_faces_end();
-       ++fit)
-  {
+       ++fit) {
     Point p1 = fit->vertex(0)->point();
     Point p2 = fit->vertex(1)->point();
     Point p3 = fit->vertex(2)->point();

--- a/src/inset_state/check_topology.cpp
+++ b/src/inset_state/check_topology.cpp
@@ -20,7 +20,7 @@ void InsetState::holes_inside_polygons() const
             std::cerr << " Hole: " << h;
             std::cerr << ". Polygon: " << ext_ring;
             std::cerr << ". GeoDiv: " << gd.id() << std::endl;
-            _Exit(20);
+            std::exit(20);
           }
         }
       }

--- a/src/inset_state/fill_with_density_rays.cpp
+++ b/src/inset_state/fill_with_density_rays.cpp
@@ -132,7 +132,7 @@ void InsetState::fill_with_density_rays()
           std::cerr << "Y-coordinate: " << y << std::endl;
           std::cerr << "Left X-coordinate: " << left_x << std::endl;
           std::cerr << "Right X-coordinate: " << right_x << std::endl;
-          _Exit(8026519);
+          std::exit(8026519);
         }
 
         // Ray is entering a GeoDiv from empty space

--- a/src/inset_state/flatten_ellipse_density.cpp
+++ b/src/inset_state/flatten_ellipse_density.cpp
@@ -332,8 +332,11 @@ void InsetState::flatten_ellipse_density()
       ell_density_prefactors.end()) -
     ell_density_prefactors.begin());
 
-  std::cerr << "Max delta rho: " << ell_density_prefactors[static_cast<unsigned int>(mx_pgn_index)]
-            << ", GeoDiv: " << pgn_id_to_geo_id[static_cast<unsigned int>(mx_pgn_index)] << std::endl;
+  std::cerr << "Max delta rho: "
+            << ell_density_prefactors[static_cast<unsigned int>(mx_pgn_index)]
+            << ", GeoDiv: "
+            << pgn_id_to_geo_id[static_cast<unsigned int>(mx_pgn_index)]
+            << std::endl;
 
   // print top 5 polygons with most delta density
   std::vector<std::pair<double, std::string>> pgn_density;
@@ -347,7 +350,8 @@ void InsetState::flatten_ellipse_density()
   // Print the top 5
   std::cerr << "Top 5 Polygons with most Delta density:" << std::endl;
   for (unsigned int i = 0;
-       i < std::min(5u, static_cast<unsigned int>(ell_density_prefactors.size()));
+       i <
+       std::min(5u, static_cast<unsigned int>(ell_density_prefactors.size()));
        ++i) {
     std::cerr << pgn_density[i].second << ": " << pgn_density[i].first
               << std::endl;

--- a/src/inset_state/inset_state.cpp
+++ b/src/inset_state/inset_state.cpp
@@ -17,7 +17,14 @@ InsetState::InsetState(std::string pos, Arguments args)
 
 double InsetState::area_error_at(const std::string &id) const
 {
-  return area_errors_.at(id);
+  try {
+    return area_errors_.at(id);
+  } catch (const std::out_of_range &e) {
+    std::cerr << "ERROR: Key '" << id << "' not found in area_errors_. "
+              << "Exception: " << e.what() << std::endl;
+    // Re-throw, or return a default value
+    throw;
+  }
 }
 
 Bbox InsetState::bbox(bool original_bbox) const
@@ -29,9 +36,8 @@ Bbox InsetState::bbox(bool original_bbox) const
   double inset_ymin = dbl_inf;
   double inset_ymax = -dbl_inf;
 #pragma omp parallel for default(none) shared(geo_divs) \
-  reduction(min                                         \
-            : inset_xmin, inset_ymin) reduction(max     \
-                                                : inset_xmax, inset_ymax)
+  reduction(min : inset_xmin, inset_ymin)               \
+  reduction(max : inset_xmax, inset_ymax)
   for (const auto &gd : geo_divs) {
     for (const auto &pwh : gd.polygons_with_holes()) {
       const auto bb = pwh.bbox();
@@ -131,7 +137,14 @@ bool InsetState::continue_integrating() const
 
 Color InsetState::color_at(const std::string &id) const
 {
-  return colors_.at(id);
+  try {
+    return colors_.at(id);
+  } catch (const std::out_of_range &e) {
+    std::cerr << "ERROR: Key '" << id << "' not found in colors_. "
+              << "Exception: " << e.what() << std::endl;
+    // Re-throw, or return a default value
+    throw;
+  }
 }
 
 bool InsetState::color_found(const std::string &id) const
@@ -303,8 +316,7 @@ void InsetState::update_delaunay_t()
 
       // Binary search to find the number of points between the two y
       // coordinates
-      auto cnt =
-        static_cast<std::size_t>(
+      auto cnt = static_cast<std::size_t>(
         std::upper_bound(y_coor_points.begin(), y_coor_points.end(), y_max) -
         std::lower_bound(y_coor_points.begin(), y_coor_points.end(), y_min));
 
@@ -390,8 +402,8 @@ void InsetState::export_time_report() const
 
     // Time taken (in seconds)
     std::string timer_task_name = inset_name_ + "_" + std::to_string(i);
-    std::string time_in_seconds =
-      std::to_string(static_cast<double>(timer.duration(timer_task_name).count()) / 1000.0);
+    std::string time_in_seconds = std::to_string(
+      static_cast<double>(timer.duration(timer_task_name).count()) / 1000.0);
     csv_rows[i + 1].push_back(time_in_seconds);
 
     // Max area error for that integration
@@ -414,11 +426,27 @@ const std::vector<GeoDiv> &InsetState::geo_divs() const
 // Const and non-const version of geo_div_at_id
 const GeoDiv &InsetState::geo_div_at_id(std::string id) const
 {
-  return geo_divs_[geo_divs_id_to_index_.at(id)];
+  try {
+    return geo_divs_[geo_divs_id_to_index_.at(id)];
+  } catch (const std::out_of_range &e) {
+    std::cerr << "ERROR: Key '" << id
+              << "' not found in geo_divs_id_to_index_. "
+              << "Exception: " << e.what() << std::endl;
+    // Re-throw, or return a default value
+    throw;
+  }
 }
 GeoDiv &InsetState::geo_div_at_id(std::string id)
 {
-  return geo_divs_[geo_divs_id_to_index_.at(id)];
+  try {
+    return geo_divs_[geo_divs_id_to_index_.at(id)];
+  } catch (const std::out_of_range &e) {
+    std::cerr << "ERROR: Key '" << id
+              << "' not found in geo_divs_id_to_index_. "
+              << "Exception: " << e.what() << std::endl;
+    // Re-throw, or return a default value
+    throw;
+  }
 }
 
 // Get unique points from GeoDivs
@@ -490,8 +518,12 @@ struct Split_by_threshold {
     double rho_min = std::numeric_limits<double>::infinity();
     double rho_max = -std::numeric_limits<double>::infinity();
 
-    for (int x = static_cast<int>(bbox.xmin()); x < static_cast<int>(bbox.xmax()); ++x) {
-      for (int y = static_cast<int>(bbox.ymin()); y < static_cast<int>(bbox.ymax()); ++y) {
+    for (int x = static_cast<int>(bbox.xmin());
+         x < static_cast<int>(bbox.xmax());
+         ++x) {
+      for (int y = static_cast<int>(bbox.ymin());
+           y < static_cast<int>(bbox.ymax());
+           ++y) {
         if (
           x < 0 || y < 0 || x >= static_cast<int>(inset_state.lx()) ||
           y >= static_cast<int>(inset_state.ly()))
@@ -755,7 +787,15 @@ double InsetState::initial_target_area() const
 
 bool InsetState::is_input_target_area_missing(const std::string &id) const
 {
-  return is_input_target_area_missing_.at(id);
+  try {
+    return is_input_target_area_missing_.at(id);
+  } catch (const std::out_of_range &e) {
+    std::cerr << "ERROR: Key '" << id
+              << "' not found in is_input_target_area_missing_. "
+              << "Exception: " << e.what() << std::endl;
+    // Re-throw, or return a default value
+    throw;
+  }
 }
 
 double InsetState::latt_const() const
@@ -1041,13 +1081,21 @@ void InsetState::store_initial_area()
 
 void InsetState::store_initial_target_area(const double override)
 {
-  initial_target_area_ = almost_equal(override, 0.0) ? total_target_area() : override;
+  initial_target_area_ =
+    almost_equal(override, 0.0) ? total_target_area() : override;
 }
 
 bool InsetState::target_area_is_missing(const std::string &id) const
 {
   // We use negative area as indication that GeoDiv has no target area
-  return target_areas_.at(id) < 0.0;
+  try {
+    return target_areas_.at(id) < 0.0;
+  } catch (const std::out_of_range &e) {
+    std::cerr << "ERROR: Key '" << id << "' not found in target_areas_. "
+              << "Exception: " << e.what() << std::endl;
+    // Re-throw, or return a default value
+    throw;
+  }
 }
 
 double InsetState::target_area_at(const std::string &id) const
@@ -1153,8 +1201,13 @@ void InsetState::update_file_prefix()
 void InsetState::update_gd_ids(
   const std::map<std::string, std::string> &gd_id_map)
 {
-  for (auto &gd : geo_divs_) {
+  try {
     gd.update_id(gd_id_map.at(gd.id()));
+  } catch (const std::out_of_range &e) {
+    std::cerr << "ERROR: Key '" << gd.id() << "' not found in gd_id_map. "
+              << "Exception: " << e.what() << std::endl;
+    // Re-throw, or return a default value
+    throw;
   }
 }
 

--- a/src/inset_state/inset_state.cpp
+++ b/src/inset_state/inset_state.cpp
@@ -1201,13 +1201,15 @@ void InsetState::update_file_prefix()
 void InsetState::update_gd_ids(
   const std::map<std::string, std::string> &gd_id_map)
 {
-  try {
-    gd.update_id(gd_id_map.at(gd.id()));
-  } catch (const std::out_of_range &e) {
-    std::cerr << "ERROR: Key '" << gd.id() << "' not found in gd_id_map. "
-              << "Exception: " << e.what() << std::endl;
-    // Re-throw, or return a default value
-    throw;
+  for (auto &gd : geo_divs_) {
+    try {
+      gd.update_id(gd_id_map.at(gd.id()));
+    } catch (const std::out_of_range &e) {
+      std::cerr << "ERROR: Key '" << gd.id() << "' not found in gd_id_map. "
+                << "Exception: " << e.what() << std::endl;
+      // Re-throw, or return a default value
+      throw;
+    }
   }
 }
 

--- a/src/inset_state/rescale_map.cpp
+++ b/src/inset_state/rescale_map.cpp
@@ -38,7 +38,7 @@ void InsetState::rescale_map()
     std::cerr
       << "ERROR: args_.n_grid_rows_or_cols must be an integer power of 2."
       << std::endl;
-    _Exit(15);
+    std::exit(15);
   }
   double latt_const;
   if (bb.xmax() - bb.xmin() > bb.ymax() - bb.ymin()) {

--- a/src/inset_state/scanline_graph.cpp
+++ b/src/inset_state/scanline_graph.cpp
@@ -105,7 +105,7 @@ std::vector<std::vector<intersection> > InsetState::intersec_with_parallel_to(
                         << " ";
             }
             std::cerr << std::endl << std::endl;
-            _Exit(932875);
+            std::exit(932875);
           }
           std::sort(intersections.begin(), intersections.end());
 

--- a/src/misc/ft_real_2d.cpp
+++ b/src/misc/ft_real_2d.cpp
@@ -18,7 +18,7 @@ void FTReal2d::allocate(const unsigned int lx, const unsigned int ly)
     std::cerr
       << "ERROR: Invalid array dimensions in FTReal2dArray::allocate_ft()"
       << std::endl;
-    _Exit(98915);
+    std::exit(98915);
   }
   lx_ = lx;
   ly_ = ly;

--- a/src/misc/parse_arguments.cpp
+++ b/src/misc/parse_arguments.cpp
@@ -218,7 +218,7 @@ Arguments parse_arguments(const int argc, const char *argv[])
     std::cerr << "To enable simplification, do not pass the -S flag.\n";
     std::cerr << "To enable quadtree, do not pass the -Q flag.\n";
     std::cerr << arguments << std::endl;
-    _Exit(18);
+    std::exit(18);
   }
 
   // Check whether n_points is specified but --simplify_and_densify not passed
@@ -242,7 +242,7 @@ Arguments parse_arguments(const int argc, const char *argv[])
     std::cerr << "QTDT method is necessary for Quadtree images." << std::endl;
     std::cerr << "To disable Triangulation, pass the -T flag." << std::endl;
     std::cerr << arguments << std::endl;
-    _Exit(17);
+    std::exit(17);
   }
 
   // Print names of geometry file
@@ -257,7 +257,7 @@ Arguments parse_arguments(const int argc, const char *argv[])
     std::cerr << "ERROR: No Geometry file provided!" << std::endl;
     std::cerr << "Please provide a geometry file in standard GeoJSON format."
               << std::endl;
-    _Exit(16);
+    std::exit(16);
   }
 
   // Check if a visual-variables file or -m flag is passed
@@ -271,7 +271,7 @@ Arguments parse_arguments(const int argc, const char *argv[])
     std::cerr << arguments << std::endl;
     std::cerr << "ERROR: No CSV file provided!" << std::endl;
     std::cerr << "To create a CSV, please use the -m flag." << std::endl;
-    _Exit(15);
+    std::exit(15);
   } else {
     args.visual_file_name = "";
   }

--- a/src/misc/time_tracker.cpp
+++ b/src/misc/time_tracker.cpp
@@ -62,8 +62,7 @@ std::chrono::milliseconds TimeTracker::duration(
   try {
     return durations_.at(task_name);
   } catch (const std::out_of_range &e) {
-    std::cerr << "ERROR: Key '" << task_name
-              << "' not found in target_areas_. "
+    std::cerr << "ERROR: Key '" << task_name << "' not found in durations_. "
               << "Exception: " << e.what() << std::endl;
     // Re-throw, or return a default value
     throw;


### PR DESCRIPTION
@adisidev 
This pull request features a few fixes to some of the project's Github issues:
- Fixes #171: Switches all uses of `_Exit()` to `std::exit()`
- Fixes #181: Adds error handling to all uses of `map.at(key)` (error handling only applied for single line functions that use `map.at(key)`)