### PR TITLE
Updare Parse_arguments.cpp

### DIFF
--- a/src/misc/parse_arguments.cpp
+++ b/src/misc/parse_arguments.cpp
@@ -73,11 +73,11 @@ Arguments parse_arguments(const int argc, const char *argv[])
     .help("Boolean: Enable Quadtree-Delaunay Triangulation Method")
     .default_value(true)
     .implicit_value(false);
-  arguments.add_argument("-S", "--simplify_and_densify")
+  arguments.add_argument("--disable_simplify_and_densify")
     .help(
-      "Boolean: Enable iterative simplification and densification of polygons")
-    .default_value(true)
-    .implicit_value(false);
+      "Boolean: Disable iterative simplification and densification of polygons. By default, simplification and densification are enabled. Pass this flag to disable them.")
+    .default_value(false)
+    .implicit_value(true);
   arguments.add_argument("--skip_projection")
     .help("Boolean: Skip projection to equal area")
     .default_value(false)
@@ -179,7 +179,7 @@ Arguments parse_arguments(const int argc, const char *argv[])
   args.world = arguments.get<bool>("--world");
   args.triangulation = arguments.get<bool>("--triangulation");
   args.qtdt_method = arguments.get<bool>("--qtdt_method");
-  args.simplify = arguments.get<bool>("--simplify_and_densify");
+  args.simplify = !arguments.get<bool>("--disable_simplify_and_densify");
   args.remove_tiny_polygons = arguments.get<bool>("--remove_tiny_polygons");
   args.min_polygon_area = arguments.get<double>("--minimum_polygon_area");
   args.rays = arguments.get<bool>("--use_ray_shooting_method");
@@ -222,19 +222,19 @@ Arguments parse_arguments(const int argc, const char *argv[])
     std::cerr << "ERROR: simplification disabled!\n";
     std::cerr << "--output_to_stdout flag is only supported with "
                  "simplification or quadtree.\n";
-    std::cerr << "To enable simplification, do not pass the -S flag.\n";
+    std::cerr << "To enable simplification, do not pass the --disable_simplify_and_densify flag.\n";
     std::cerr << "To enable quadtree, do not pass the -Q flag.\n";
     std::cerr << arguments << std::endl;
     std::exit(18);
   }
 
-  // Check whether n_points is specified but --simplify_and_densify not passed
+  // Check whether n_points is specified but simplification/densification is disabled
   if (!args.simplify) {
     std::cerr << "WARNING: Simplification and densification disabled! "
-              << "Polygons will not simplified (or densified). "
-              << "This may result and in polygon intersections. "
+              << "Polygons will not be simplified (or densified). "
+              << "This may result in polygon intersections. "
               << "Thus, we are turning off topology checks. "
-              << "To enable simplification, pass the -S flag." << std::endl;
+              << "To enable simplification, do not pass the --disable_simplify_and_densify flag." << std::endl;
     if (arguments.is_used("--n_points")) {
       std::cerr << "--n_points ignored." << std::endl;
     }


### PR DESCRIPTION
Previously, the --simplify_and_densify flag enabled features by default, but passing the flag would actually disable them, which was counterintuitive. This has been fixed by replacing it with a new flag, --disable_simplify_and_densify, which is disabled by default—so simplification and densification are now always enabled unless this flag is explicitly passed.

@adisidev 

#291 