### PR TITLE
Add citation and update readme for topology-preserving line densification paper

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -17,6 +17,15 @@
     "adisidev",
     "virtualenv",
     "venv",
-    "lldb"
+    "lldb",
+    "Carto",
+    "densification",
+    "Nihal",
+    "Miaji",
+    "Singhania",
+    "Callista",
+    "Atima",
+    "Tharatipyakul",
+    "cartograms"
   ]
 }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,6 +4,7 @@
   "retryCount": 3,
   "ignorePatterns": [
     { "pattern": "go-cart\\.io" },
+    { "pattern": "zenodo\\.org/badge/281575635\\.svg" },
     { "pattern": "zenodo\\.org/badge/latestdoi/281575635" },
     { "pattern": "www\\.tandfonline\\.com/doi/full/10\\.1080/15230406\\.2026\\.2625329" },
     { "pattern": "doi\\.org/10\\.1080/15230406\\.2026\\.2625329" },

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -4,8 +4,11 @@
   "retryCount": 3,
   "ignorePatterns": [
     { "pattern": "go-cart\\.io" },
+    { "pattern": "zenodo\\.org/badge/latestdoi/281575635" },
+    { "pattern": "www\\.tandfonline\\.com/doi/full/10\\.1080/15230406\\.2026\\.2625329" },
+    { "pattern": "doi\\.org/10\\.1080/15230406\\.2026\\.2625329" },
+    { "pattern": "doi\\.org/10\\.1073/pnas\\.1712674115" },
     { "pattern": "pnas\\.org/content/115/10/E2156" },
-    { "pattern": "doi\\.org/10\\.1073/pnas\\.0400280101" },
     { "pattern": "gnu\\.org/licenses/agpl-3\\.0" }
   ]
 }

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,37 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite the paper below."
+type: software
+title: "cartogram-cpp"
+repository-code: "https://github.com/mgastner/cartogram-cpp"
+url: "https://go-cart.io"
+license: "AGPL-3.0-only"
+
+authors:
+  - family-names: "Gastner"
+    given-names: "Michael T."
+  - family-names: "Miaji"
+    given-names: "Nihal Z."
+  - family-names: "Singhania"
+    given-names: "Adi"
+
+preferred-citation:
+  type: article
+  title: "Topology-preserving line densification for creating contiguous cartograms"
+  authors:
+    - family-names: "Miaji"
+      given-names: "Nihal Z."
+    - family-names: "Singhania"
+      given-names: "Adi"
+    - family-names: "Goh"
+      given-names: "Matthias E."
+    - family-names: "Le"
+      given-names: "Callista"
+    - family-names: "Tharatipyakul"
+      given-names: "Atima"
+    - family-names: "Gastner"
+      given-names: "Michael T."
+  journal: "Cartography and Geographic Information Science"
+  year: 2026
+  start: 1
+  end: 16
+  doi: "10.1080/15230406.2026.2625329"

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@
 
 This repository contains the underlying C++ program that powers [go-cart.io](https://go-cart.io). If you'd only like to create a cartogram, you may find it easier to visit the website directly. Otherwise, if you'd like to make code contributions, feature suggestions and/or play with the inner workings of our cartogram generator, you're at the right place!
 
-This program uses the fast flow-based method developed by Michael T. Gastner, Vivien Seguy, and Pratyush More. For more information, you may refer to the following [paper](https://www.pnas.org/content/115/10/E2156):
+This program implements 5FCarto, a topology-preserving contiguous cartogram generator that combines the topology-preserving line densification method developed by Nihal Z. Miaji, Adi Singhania, Matthias E. Goh, Callista Le, Atima Tharatipyakul, and Michael T. Gastner with the fast flow-based method developed by Michael T. Gastner, Vivien Seguy, and Pratyush More. For more information, you may refer to the following [paper](https://www.tandfonline.com/doi/full/10.1080/15230406.2026.2625329):
 
-Gastner MT, Seguy V, More P. _Fast flow-based algorithm for creating density-equalizing map projections_. Proc Natl Acad Sci USA 115(10):E2156–E2164 (2018). <https://doi.org/10.1073/pnas.0400280101>
+Miaji NZ, Singhania A, Goh ME, Le C, Tharatipyakul A, Gastner MT. _Topology-preserving line densification for creating contiguous cartograms_. Cartography and Geographic Information Science 1–16 (2026). <https://doi.org/10.1080/15230406.2026.2625329>
 
-Data produced by code in this repository are subject to the MIT license found [here](./LICENSE) and should cite the aforementioned paper by Gastner et al. (2018).
+Data produced by code in this repository are subject to the MIT license and should cite the aforementioned paper by Miaji et al. (2026).
+
+The underlying flow-based cartogram algorithm is described in:
+
+Gastner MT, Seguy V, More P. _Fast flow-based algorithm for creating density-equalizing map projections_. Proc Natl Acad Sci USA 115(10):E2156–E2164 (2018). <https://doi.org/10.1073/pnas.1712674115>
 
 ## Usage
 


### PR DESCRIPTION
Additionally, this PR fixes the wrong DOI for the 2018 paper. Initially, it pointed to the older 2004 diffusion paper.

Closes
- https://github.com/mgastner/cartogram-cpp/issues/311